### PR TITLE
fix: restore metrics moved by Beszel 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Beszel Home Assistant Integration
 
 [![Check](https://github.com/maxexcloo/homeassistant-beszel-integration/actions/workflows/check.yaml/badge.svg)](https://github.com/maxexcloo/homeassistant-beszel-integration/actions/workflows/check.yaml)
-[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](custom_components/beszel/manifest.json)
+[![Version](https://img.shields.io/badge/version-0.2.1-blue.svg)](custom_components/beszel/manifest.json)
 [![Licence](https://img.shields.io/badge/licence-AGPL--3.0-blue.svg)](LICENSE)
 
 Monitor Beszel systems in Home Assistant with automatically discovered diagnostic

--- a/custom_components/beszel/api.py
+++ b/custom_components/beszel/api.py
@@ -91,6 +91,30 @@ class BeszelApiClient:
                 ) from err
             raise
 
+    async def async_get_system_details(self):
+        """Fetch static system details keyed by system ID."""
+        await self._ensure_auth()
+        try:
+            records = await asyncio.to_thread(
+                self._client.collection("system_details").get_full_list,
+            )
+        except ClientResponseError as err:
+            if err.status in (401, 403):
+                self._is_authenticated = False
+                raise BeszelApiAuthError(
+                    "Token likely expired, re-authentication needed"
+                ) from err
+            if err.status == 404:
+                return {}
+            raise
+        details = {}
+        for record in records:
+            fields = vars(record)
+            system_id = fields.get("system")
+            if system_id:
+                details[str(system_id)] = fields
+        return details
+
     async def async_get_systems(self):
         """Fetch all systems from the Beszel Hub."""
         await self._ensure_auth()

--- a/custom_components/beszel/const.py
+++ b/custom_components/beszel/const.py
@@ -16,8 +16,10 @@ ATTR_THREADS = "t"
 ATTR_UPTIME = "u"
 
 # Beszel SystemStats fields
+ATTR_BANDWIDTH = "b"
 ATTR_BATTERY = "bat"
 ATTR_CPU_PERCENT = "cpu"
+ATTR_DISK_IO = "dio"
 ATTR_DISK_IO_STATS = "dios"
 ATTR_DISK_PERCENT = "dp"
 ATTR_DISK_READ_PS_MB = "dr"

--- a/custom_components/beszel/coordinator.py
+++ b/custom_components/beszel/coordinator.py
@@ -8,9 +8,40 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import BeszelApiAuthError
-from .const import DOMAIN
+from .const import (
+    ATTR_CORES,
+    ATTR_CPU_MODEL,
+    ATTR_KERNEL_VERSION,
+    ATTR_OS,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Beszel system_details fields mapped onto their legacy system info keys.
+_DETAILS_TO_INFO = {
+    "cores": ATTR_CORES,
+    "cpu": ATTR_CPU_MODEL,
+    "kernel": ATTR_KERNEL_VERSION,
+    "os": ATTR_OS,
+}
+
+
+def _mapping(value):
+    """Return a mapping or an empty mapping for unavailable data."""
+    return value if isinstance(value, dict) else {}
+
+
+def _merge_system_info(info, details):
+    """Merge static Beszel details into a system info mapping."""
+    merged = dict(_mapping(info))
+    for detail_key, info_key in _DETAILS_TO_INFO.items():
+        if info_key in merged:
+            continue
+        value = details.get(detail_key)
+        if value is not None and value != "":
+            merged[info_key] = value
+    return merged or None
 
 
 class BeszelDataUpdateCoordinator(DataUpdateCoordinator):
@@ -51,8 +82,11 @@ class BeszelDataUpdateCoordinator(DataUpdateCoordinator):
                     self.api_client.host,
                     system,
                 )
+            details_map = await self._fetch_system_details()
             tasks = [
-                self._fetch_individual_system_data(system)
+                self._fetch_individual_system_data(
+                    system, details_map.get(system["id"], {})
+                )
                 for system in systems_with_ids
             ]
 
@@ -75,7 +109,9 @@ class BeszelDataUpdateCoordinator(DataUpdateCoordinator):
                     cached_data = (self.data or {}).get(system_id, {})
                     if not isinstance(cached_data, dict):
                         cached_data = {}
-                    info = system.get("info")
+                    info = _merge_system_info(
+                        system.get("info"), details_map.get(system_id, {})
+                    )
                     if info is None:
                         info = cached_data.get("info")
                     all_system_data[system_id] = {
@@ -101,14 +137,28 @@ class BeszelDataUpdateCoordinator(DataUpdateCoordinator):
                 f"Error communicating with Beszel Hub {self.api_client.host}: {err}"
             ) from err
 
-    async def _fetch_individual_system_data(self, system):
+    async def _fetch_system_details(self):
+        """Fetch static system details, tolerating hubs that lack them."""
+        try:
+            return await self.api_client.async_get_system_details()
+        except BeszelApiAuthError:
+            raise
+        except Exception as err:  # noqa: BLE001 - details are best-effort
+            _LOGGER.warning(
+                "Error fetching system details from Beszel Hub %s: %s",
+                self.api_client.host,
+                err,
+            )
+            return {}
+
+    async def _fetch_individual_system_data(self, system, details):
         """Fetch stats and 'info' for a single system."""
         system_id = system["id"]
         stats = await self.api_client.async_get_latest_system_stats(system_id)
 
         return {
             "id": system_id,
-            "info": system.get("info"),
+            "info": _merge_system_info(system.get("info"), details),
             "name": system.get("name", system_id),
             "stats": stats,
             "status": system.get("status", "unknown"),

--- a/custom_components/beszel/manifest.json
+++ b/custom_components/beszel/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/maxexcloo/homeassistant-beszel-integration/issues",
   "loggers": ["pocketbase"],
   "requirements": ["pocketbase==0.17.3"],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/custom_components/beszel/sensor.py
+++ b/custom_components/beszel/sensor.py
@@ -23,10 +23,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_AGENT_VERSION,
+    ATTR_BANDWIDTH,
     ATTR_BATTERY,
     ATTR_CORES,
     ATTR_CPU_MODEL,
     ATTR_CPU_PERCENT,
+    ATTR_DISK_IO,
     ATTR_DISK_IO_STATS,
     ATTR_DISK_PERCENT,
     ATTR_DISK_READ_PS_MB,
@@ -100,6 +102,27 @@ def _array_value(data, key, index, precision=2):
         return round(float(value), precision)
     except TypeError, ValueError:
         return None
+
+
+def _data_rate_megabytes(data, byte_key, index, legacy_key):
+    """Return MB/s from a byte counter with a legacy MB/s fallback."""
+    values = data.get(byte_key)
+    if (
+        isinstance(values, (list, tuple))
+        and len(values) > index
+        and values[index] is not None
+    ):
+        try:
+            return round(float(values[index]) / (1024 * 1024), 2)
+        except TypeError, ValueError:
+            pass
+    legacy = data.get(legacy_key)
+    if legacy is not None:
+        try:
+            return round(float(legacy), 2)
+        except TypeError, ValueError:
+            return None
+    return None
 
 
 def _battery_percent(data):
@@ -328,6 +351,9 @@ STATS_SENSOR_DESCRIPTIONS = (
         icon="mdi:arrow-down-bold-circle-outline",
         native_unit=UnitOfDataRate.MEGABYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: _data_rate_megabytes(
+            data, ATTR_DISK_IO, 0, ATTR_DISK_READ_PS_MB
+        ),
     ),
     BeszelSensorDescription(
         api_key="disk_read_time_percent",
@@ -384,6 +410,9 @@ STATS_SENSOR_DESCRIPTIONS = (
         icon="mdi:arrow-up-bold-circle-outline",
         native_unit=UnitOfDataRate.MEGABYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: _data_rate_megabytes(
+            data, ATTR_DISK_IO, 1, ATTR_DISK_WRITE_PS_MB
+        ),
     ),
     BeszelSensorDescription(
         api_key="disk_write_time_percent",
@@ -439,6 +468,9 @@ STATS_SENSOR_DESCRIPTIONS = (
         icon="mdi:download-network-outline",
         native_unit=UnitOfDataRate.MEGABYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: _data_rate_megabytes(
+            data, ATTR_BANDWIDTH, 1, ATTR_NET_RECV_PS_MB
+        ),
     ),
     BeszelSensorDescription(
         api_key=ATTR_NET_SENT_PS_MB,
@@ -447,6 +479,9 @@ STATS_SENSOR_DESCRIPTIONS = (
         icon="mdi:upload-network-outline",
         native_unit=UnitOfDataRate.MEGABYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: _data_rate_megabytes(
+            data, ATTR_BANDWIDTH, 0, ATTR_NET_SENT_PS_MB
+        ),
     ),
     BeszelSensorDescription(
         api_key="status",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,3 +80,37 @@ class BeszelApiClientTests(unittest.IsolatedAsyncioTestCase):
                 await client.async_get_latest_system_stats("system")
 
         self.assertFalse(client._is_authenticated)
+
+    async def test_system_details_are_keyed_by_system(self):
+        """System details are returned keyed by their system identifier."""
+        records = [
+            SimpleNamespace(system="one", kernel="6.1"),
+            SimpleNamespace(system="two", kernel="5.15"),
+            SimpleNamespace(name="orphan"),
+        ]
+        collection = MagicMock()
+        collection.get_full_list.return_value = records
+        pocketbase = MagicMock()
+        pocketbase.collection.return_value = collection
+
+        with patch("custom_components.beszel.api.PocketBase", return_value=pocketbase):
+            client = BeszelApiClient("beszel.local", "user", "password")
+            client._ensure_auth = AsyncMock()
+            result = await client.async_get_system_details()
+
+        self.assertEqual(set(result), {"one", "two"})
+        self.assertEqual(result["one"]["kernel"], "6.1")
+
+    async def test_missing_system_details_collection_is_tolerated(self):
+        """Hubs without a system_details collection return no details."""
+        collection = MagicMock()
+        collection.get_full_list.side_effect = ClientResponseError(status=404)
+        pocketbase = MagicMock()
+        pocketbase.collection.return_value = collection
+
+        with patch("custom_components.beszel.api.PocketBase", return_value=pocketbase):
+            client = BeszelApiClient("beszel.local", "user", "password")
+            client._ensure_auth = AsyncMock()
+            result = await client.async_get_system_details()
+
+        self.assertEqual(result, {})

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -23,6 +23,10 @@ class FakeApiClient:
             raise RuntimeError("stats unavailable")
         return {"cpu": 12.5}
 
+    async def async_get_system_details(self):
+        """Return no static system details by default."""
+        return {}
+
     async def async_get_systems(self):
         """Return one malformed and two valid systems."""
         return [
@@ -107,3 +111,62 @@ class BeszelDataUpdateCoordinatorTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(data["system"]["info"])
         self.assertIsNone(data["system"]["stats"])
+
+    async def test_system_details_merge_into_info(self):
+        """Static details populate the info mapping for newer hubs."""
+
+        class DetailedApi(FakeApiClient):
+            async def async_get_systems(self):
+                return [{"id": "system", "name": "Server", "status": "up"}]
+
+            async def async_get_system_details(self):
+                return {
+                    "system": {
+                        "cores": 4,
+                        "cpu": "ARM Cortex-A76",
+                        "kernel": "6.1.0-rpi8",
+                        "os": 0,
+                    }
+                }
+
+        coordinator = BeszelDataUpdateCoordinator(
+            FakeHomeAssistant(),
+            api_client=DetailedApi(),
+            config_entry_id="entry",
+            update_interval_seconds=60,
+        )
+
+        data = await coordinator._async_update_data()
+
+        self.assertEqual(data["system"]["info"]["c"], 4)
+        self.assertEqual(data["system"]["info"]["m"], "ARM Cortex-A76")
+        self.assertEqual(data["system"]["info"]["k"], "6.1.0-rpi8")
+        self.assertEqual(data["system"]["info"]["os"], 0)
+
+    async def test_info_fields_are_not_overridden_by_details(self):
+        """Existing info values win over the static details fallback."""
+
+        class DetailedApi(FakeApiClient):
+            async def async_get_systems(self):
+                return [
+                    {
+                        "id": "system",
+                        "name": "Server",
+                        "status": "up",
+                        "info": {"k": "legacy-kernel"},
+                    }
+                ]
+
+            async def async_get_system_details(self):
+                return {"system": {"kernel": "new-kernel"}}
+
+        coordinator = BeszelDataUpdateCoordinator(
+            FakeHomeAssistant(),
+            api_client=DetailedApi(),
+            config_entry_id="entry",
+            update_interval_seconds=60,
+        )
+
+        data = await coordinator._async_update_data()
+
+        self.assertEqual(data["system"]["info"]["k"], "legacy-kernel")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -73,6 +73,48 @@ class BeszelSensorTests(unittest.IsolatedAsyncioTestCase):
             {"beszel_entry_system_status_status"},
         )
 
+    def test_data_rates_read_byte_counters(self):
+        """Byte counters are converted to megabytes per second."""
+        coordinator = MagicMock()
+        coordinator.config_entry_id = "entry"
+        coordinator.data = {
+            "system": {
+                "id": "system",
+                "info": {},
+                "name": "Server",
+                "stats": {"b": [2097152, 1048576], "dio": [524288, 262144]},
+                "status": "up",
+            }
+        }
+
+        sensors = _create_available_sensors(coordinator)
+        by_id = {sensor.unique_id: sensor for sensor in sensors}
+
+        self.assertEqual(by_id["beszel_entry_system_stats_ns"].native_value, 2.0)
+        self.assertEqual(by_id["beszel_entry_system_stats_nr"].native_value, 1.0)
+        self.assertEqual(by_id["beszel_entry_system_stats_dr"].native_value, 0.5)
+        self.assertEqual(by_id["beszel_entry_system_stats_dw"].native_value, 0.25)
+
+    def test_data_rates_fall_back_to_legacy_values(self):
+        """Legacy MB/s values are used when byte counters are absent."""
+        coordinator = MagicMock()
+        coordinator.config_entry_id = "entry"
+        coordinator.data = {
+            "system": {
+                "id": "system",
+                "info": {},
+                "name": "Server",
+                "stats": {"nr": 1.5, "ns": 2.5},
+                "status": "up",
+            }
+        }
+
+        sensors = _create_available_sensors(coordinator)
+        by_id = {sensor.unique_id: sensor for sensor in sensors}
+
+        self.assertEqual(by_id["beszel_entry_system_stats_ns"].native_value, 2.5)
+        self.assertEqual(by_id["beszel_entry_system_stats_nr"].native_value, 1.5)
+
     def test_new_metrics_are_discovered_on_later_data(self):
         """A later coordinator snapshot exposes newly reported metrics."""
         coordinator = MagicMock()


### PR DESCRIPTION
Beszel 0.19 moved network and disk throughput to byte counters (b/dio) and kernel, cores, CPU model, and OS into the system_details collection. Read the new fields with legacy fallbacks so those sensors are discovered again.